### PR TITLE
Remove rounding randomized positions

### DIFF
--- a/src/layout/position.js
+++ b/src/layout/position.js
@@ -12,8 +12,8 @@ let setInitialPositionState = function( node, state ){
   }
 
   assign( scratch, state.randomize ? {
-    x: bb.x1 + Math.round( Math.random() * bb.w ),
-    y: bb.y1 + Math.round( Math.random() * bb.h )
+    x: bb.x1 + Math.random() * bb.w,
+    y: bb.y1 + Math.random() * bb.h
   } : {
     x: p.x,
     y: p.y


### PR DESCRIPTION
Remove rounding randomized positions, because in headless mode with no bbox, bbox is inferred as { 0, 0, 1, 1 }, possibly generating random position { 0, 0 }, producing NaN body force and causing layout never finish.

Current workaround is to set an explicit larger bbox:

```
cytoscape({
	headless: true,
    styleEnabled: false,
	layout: {
		name: 'euler',
		boundingBox: { x1: 0, y1: 0, w: 1000, h: 1000 },
	    randomize: true,
		animate: false,
	},
});
```