### PR TITLE
Add demo with a large amount chain nodes (currently 5000 but variable)

### DIFF
--- a/demo-large.html
+++ b/demo-large.html
@@ -1,0 +1,93 @@
+<!DOCTYPE>
+
+<html>
+
+	<head>
+		<title>cytoscape-euler.js demo</title>
+
+		<meta name="viewport" content="width=device-width, user-scalable=no, initial-scale=1, maximum-scale=1">
+
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/bluebird/3.5.0/bluebird.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/fetch/2.0.3/fetch.min.js"></script>
+		<script src="https://unpkg.com/cytoscape/dist/cytoscape.umd.js"></script>
+
+		<!-- for testing with local version of cytoscape.js -->
+		<!--<script src="../cytoscape.js/build/cytoscape.js"></script>-->
+
+		<script src="cytoscape-euler.js"></script>
+
+		<style>
+			body {
+				font-family: helvetica neue, helvetica, liberation sans, arial, sans-serif;
+				font-size: 14px;
+			}
+
+			#cy {
+				position: absolute;
+				left: 0;
+				top: 0;
+				bottom: 0;
+				right: 0;
+				z-index: 999;
+			}
+
+			h1 {
+				opacity: 0.5;
+				font-size: 1em;
+				font-weight: bold;
+			}
+		</style>
+
+		<script>
+			document.addEventListener('DOMContentLoaded', function(){
+				const n = 5000;
+				document.getElementById("h1").innerText+=` (${n} nodes)`;
+				const elements = Array.from(Array(n).keys()).map(i => ({data: {id: 'n'+i}, group: 'nodes', position: {x:0, y:0}}));
+				const edges = Array.from(Array(n-1).keys()).map(i => ({group: 'edges', data: {id: 'e'+i, source: 'n'+i, target: 'n'+(i+1) }}));
+				elements.push(...edges);
+				var cy = window.cy = cytoscape({
+					container: document.getElementById('cy'),
+
+					layout: {
+						name: 'euler',
+						randomize: false
+					},
+
+					style: [
+						{
+							selector: 'node',
+							style: {
+								'content': 'data(name)'
+							}
+						},
+
+						{
+							selector: 'edge',
+							style: {
+								'target-arrow-shape': 'triangle'
+							}
+						},
+
+						{
+							selector: ':selected',
+							style: {
+
+							}
+						}
+					],
+
+					elements
+				});
+
+			});
+		</script>
+	</head>
+
+	<body>
+		<h1 id="h1">cytoscape-euler large chain demo</h1>
+
+		<div id="cy"></div>
+
+	</body>
+
+</html>

--- a/src/layout/index.js
+++ b/src/layout/index.js
@@ -12,9 +12,27 @@ class Layout {
   constructor( options ){
     let o = this.options = assign( {}, defaults, options );
 
+		let nodes = o.eles.nodes();
+		// prevent infinite loop and memory overflow when nodes occupy the same position
+		if(!o.randomize)
+		{
+			nodes = nodes.sort((a,b)=>a.position().x-b.position().x);
+			const prev = {x: 0, y: 0};
+			const pos = {};
+			nodes.forEach(n=>
+			{
+				Object.assign(pos,n.position());
+				if(Math.abs(prev.x - pos.x) < o.theta && Math.abs(prev.y - pos.y) < o.theta)
+				{
+					n.position({x: Math.random()*100, y: Math.random()*100});
+				}
+				Object.assign(prev,pos);
+			});
+		}
+
     let s = this.state = assign( {}, o, {
       layout: this,
-      nodes: o.eles.nodes(),
+      nodes,
       edges: o.eles.edges(),
       tickIndex: 0,
       firstUpdate: true


### PR DESCRIPTION
The nodes are dynamically generated and with positions set to x:0 and y:0.
This PR is build upon <https://github.com/cytoscape/cytoscape.js-euler/pull/25> so that it doesn't crash without the randomize parameter set to true.
This is done on purpose to verify that this problem stays fixed.
Additionally, this allows testing the performance of this layout on large graphs.